### PR TITLE
stop warnings from bubbling up to error handlers.

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -40,6 +40,7 @@ class Html2Text {
 		$html = static::fixNewlines($html);
 
 		$doc = new \DOMDocument();
+        libxml_use_internal_errors(true);
 		if (!$doc->loadHTML($html)) {
 			throw new Html2TextException("Could not load HTML - badly formed?", $html);
 		}


### PR DESCRIPTION
included libxml_use_internal_errors(true) before the loadHTML to stop warnings from bubbling up to error handlers.